### PR TITLE
Include action and action_sub in default metrics

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,7 +2,7 @@ Revision history for Catalyst::Plugin::PrometheusTiny
 
 
     * add META resources
-    * add action and action_sub labels to the metrics
+    * add action_class and action_sub labels to the metrics
 
 0.004 - 2021-06-06
 

--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@ Revision history for Catalyst::Plugin::PrometheusTiny
 
 
     * add META resources
+    * add action and action_sub labels to the metrics
 
 0.004 - 2021-06-06
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Peter Mottram (SysPete) <peter@sysnix.com>
 
 # CONTRIBUTORS
 
-None yet.
+Graham Christensen <graham@grahamc.com>
 
 # COPYRIGHT
 

--- a/lib/Catalyst/Plugin/PrometheusTiny.pm
+++ b/lib/Catalyst/Plugin/PrometheusTiny.pm
@@ -114,10 +114,10 @@ after finalize => sub {
     my $action   = $c->action;
 
     my $labels = {
-        code       => $response->code,
-        method     => $request->method,
-        action     => $action->class,
-        action_sub => $action->name
+        action_class => $action->class,
+        action_sub   => $action->name,
+        code         => $response->code,
+        method       => $request->method,
     };
 
     $prometheus->histogram_observe(

--- a/t/app.t
+++ b/t/app.t
@@ -13,14 +13,14 @@ my @cases = (
     {
         name   => 'default config',
         expect =>
-          superbagof('http_requests_total{action="TestApp::Controller::Root",action_sub="index",code="200",method="GET"} 1'),
+          superbagof('http_requests_total{action_class="TestApp::Controller::Root",action_sub="index",code="200",method="GET"} 1'),
     },
     {
         name     => 'set endpoint in config',
         config   => { endpoint => '/testme' },
         endpoint => '/testme',
         expect   =>
-          superbagof('http_requests_total{action="TestApp::Controller::Root",action_sub="index",code="200",method="GET"} 1'),
+          superbagof('http_requests_total{action_class="TestApp::Controller::Root",action_sub="index",code="200",method="GET"} 1'),
     },
 );
 

--- a/t/app.t
+++ b/t/app.t
@@ -13,14 +13,14 @@ my @cases = (
     {
         name   => 'default config',
         expect =>
-          superbagof('http_requests_total{code="200",method="GET"} 1'),
+          superbagof('http_requests_total{action="TestApp::Controller::Root",action_sub="index",code="200",method="GET"} 1'),
     },
     {
         name     => 'set endpoint in config',
         config   => { endpoint => '/testme' },
         endpoint => '/testme',
         expect   =>
-          superbagof('http_requests_total{code="200",method="GET"} 1'),
+          superbagof('http_requests_total{action="TestApp::Controller::Root",action_sub="index",code="200",method="GET"} 1'),
     },
 );
 


### PR DESCRIPTION
With the following three goals:

1. identify popular and slow actions
2. track performance improvements / regressions on those actions
3. determine if some actions are totally unused in a period of time

One down side to this is sites with a very large number of actions
and subs will have quite a large number of exported metrics. One
way to mitigate this would be make these additional metrics
optional, another is to punt this implementation in to a separate
module or user implementation.